### PR TITLE
chore: Bump version and dependencies

### DIFF
--- a/linglong.yaml
+++ b/linglong.yaml
@@ -2,14 +2,14 @@ version: "1"
 package:
   id: cn.org.linyaps.preloader
   name: linyaps preloader
-  version: 25.2.0.3
+  version: 25.2.0.4
   kind: app
   description: |
     A preloader for accelerating application launching speed
 command:
   - /opt/apps/cn.org.linyaps.preloader/files/bin/preloader
-base: org.deepin.base/25.2.0
-runtime: org.deepin.runtime.dtk/25.2.0
+base: org.deepin.base/25.2.1
+runtime: org.deepin.runtime.dtk/25.2.1
 build: |
   cmake -B linyaps-build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${PREFIX}
   cmake --build linyaps-build

--- a/mips64/linglong.yaml
+++ b/mips64/linglong.yaml
@@ -1,0 +1,1 @@
+../linglong.yaml


### PR DESCRIPTION
Update the preloader version to 25.2.0.4, deepin base to 25.2.1, and dtk runtime to 25.2.1 in `linglong.yaml`. This change ensures the preloader uses the latest deepin base and dtk runtime for better compatibility and access to the newest features and bug fixes provided by those dependencies. Updating the preloader version also reflects the changes in dependencies.

版本和依赖项更新

更新 linglong.yaml 文件中的 preloader 版本到 25.2.0.4，deepin base 版本 到 25.2.1，以及 dtk runtime 版本到 25.2.1。此更改确保 preloader 使用最新 的 deepin base 和 dtk runtime，从而实现更好的兼容性，并访问这些依赖项提
供的最新功能和错误修复。更新 preloader 版本也反映了依赖项的更改。